### PR TITLE
Issue 8

### DIFF
--- a/conflate.go
+++ b/conflate.go
@@ -129,7 +129,7 @@ func (c *Conflate) SetSchemaData(data []byte) error {
 	if err != nil {
 		return wrapError(err, "Schema is not valid json")
 	}
-	err = validateSchemaTemporary(schema)
+	err = validateSchema(schema)
 	if err != nil {
 		return wrapError(err, "The schema is not valid against the meta-schema http://json-schema.org/draft-04/schema")
 	}

--- a/format.go
+++ b/format.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/xml"
 	"fmt"
-	"github.com/xeipuuv/gojsonschema"
+	"github.com/the4thamigo-uk/gojsonschema"
 	"golang.org/x/net/html"
 	"regexp"
 	"strings"

--- a/schema.go
+++ b/schema.go
@@ -1,7 +1,7 @@
 package conflate
 
 import (
-	"github.com/xeipuuv/gojsonschema"
+	"github.com/the4thamigo-uk/gojsonschema"
 	"reflect"
 	"strings"
 )
@@ -16,18 +16,6 @@ func validateSchema(schema interface{}) error {
 		}
 	}
 	return validate(schema, metaSchema)
-}
-
-// TODO: remove this version of validateSchema when the fix for https://github.com/xeipuuv/gojsonschema/issues/170 is done
-func validateSchemaTemporary(schema interface{}) error {
-	dataLoader := gojsonschema.NewGoLoader(schema)
-	schemaLoader := gojsonschema.NewReferenceLoader("http://json-schema.org/draft-04/schema")
-	formatErrs.clear()
-	result, err := gojsonschema.Validate(schemaLoader, dataLoader)
-	if err != nil {
-		return wrapError(err, "An error occurred during validation")
-	}
-	return processResult(result)
 }
 
 func validate(data interface{}, schema interface{}) error {

--- a/schema_test.go
+++ b/schema_test.go
@@ -13,6 +13,16 @@ func TestValidateSchema(t *testing.T) {
 	assert.Nil(t, err)
 	err = validateSchema(schema)
 	assert.Nil(t, err)
+	assert.NotNil(t, metaSchema)
+}
+
+func TestValidateSchema_AnyOf(t *testing.T) {
+	data := `{ "type": "object", "properties": { "test": { "anyOf": [ { "type": "integer" } ] } } }`
+	var schema interface{}
+	err := jsonUnmarshal([]byte(data), &schema)
+	assert.Nil(t, err)
+	err = validateSchema(schema)
+	assert.Nil(t, err)
 }
 
 func TestValidateSchema_Error(t *testing.T) {
@@ -26,12 +36,6 @@ func TestValidateSchema_Error(t *testing.T) {
 	err := validateSchema("test")
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "Could not load json meta-schema")
-}
-
-func TestValidateSchemaTemporary_Error(t *testing.T) {
-	err := validateSchemaTemporary(make(chan int))
-	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "An error occurred during validation")
 }
 
 func TestValidate(t *testing.T) {


### PR DESCRIPTION
Removed the workaround to validate schemas since this no longer works with the latest gojsonschema/gojsonreference (we are waiting for a PR). Temporarily we will reference the patched version github.com/johandorland/gojsonreference.