### PR TITLE
Separate Schema from Conflate

### DIFF
--- a/conflate/main.go
+++ b/conflate/main.go
@@ -22,7 +22,7 @@ func main() {
 
 	var data dataFlag
 	flag.Var(&data, "data", "The path/url of JSON/YAML/TOML data, or 'stdin' to read from standard input")
-	schema := flag.String("schema", "", "The path/url of a JSON v4 schema file")
+	schemaFile := flag.String("schema", "", "The path/url of a JSON v4 schema file")
 	defaults := flag.Bool("defaults", false, "Apply defaults from schema to data")
 	validate := flag.Bool("validate", false, "Validate the data against the schema")
 	format := flag.String("format", "", "Output format of the data JSON/YAML/TOML")
@@ -62,16 +62,18 @@ func main() {
 		}
 	}
 
-	if *schema != "" {
-		err := c.SetSchemaFile(*schema)
+	var schema *conflate.Schema
+	if *schemaFile != "" {
+		s, err := conflate.NewSchemaFile(*schemaFile)
 		failIfError(err)
+		schema = s
 	}
 	if *defaults {
-		err := c.ApplyDefaults()
+		err := c.ApplyDefaults(schema)
 		failIfError(err)
 	}
 	if *validate {
-		err := c.Validate()
+		err := c.Validate(schema)
 		failIfError(err)
 	}
 	if *format != "" {

--- a/example/main.go
+++ b/example/main.go
@@ -37,19 +37,19 @@ func main() {
 		return
 	}
 	// load a json schema
-	err = c.SetSchemaFile(path.Join(thisDir, "../testdata/test.schema.json"))
+	schema, err := conflate.NewSchemaFile(path.Join(thisDir, "../testdata/test.schema.json"))
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 	// apply defaults defined in schema to merged data
-	err = c.ApplyDefaults()
+	err = c.ApplyDefaults(schema)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
 	// validate merged data against schema
-	err = c.Validate()
+	err = c.Validate(schema)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/filedata.go
+++ b/filedata.go
@@ -135,3 +135,26 @@ func expand(b []byte) ([]byte, int) {
 			return "$" + name
 		})), c
 }
+
+var getSchema = getDefaultSchema
+
+func getDefaultSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"anyOf": []interface{}{
+			map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					Includes: map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "string",
+						},
+					},
+				},
+			},
+			map[string]interface{}{
+				"type": "null",
+			},
+		},
+	}
+}

--- a/schema_test.go
+++ b/schema_test.go
@@ -5,6 +5,37 @@ import (
 	"testing"
 )
 
+func TestSchema_NewSchemaBadUrl(t *testing.T) {
+	_, err := NewSchemaFile(`!"£$%^&*()`)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Failed to obtain url to schema file")
+}
+
+func TestSchema_NewSchemaMissingError(t *testing.T) {
+	_, err := NewSchemaFile("missing file")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Failed to load schema url")
+}
+
+func TestSchema_NewSchemaBadJsonError(t *testing.T) {
+	_, err := NewSchemaFile("conflate.go")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Schema is not valid json")
+}
+
+func TestSchema_NewSchemaBadSchemaError(t *testing.T) {
+	_, err := NewSchemaFile("testdata/bad.schema.json")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "The schema is not valid against the meta-schema")
+}
+
+func TestSchema_NewSchema(t *testing.T) {
+	s, err := NewSchemaFile("testdata/test.schema.json")
+	assert.Nil(t, err)
+	assert.NotNil(t, s)
+	assert.NotNil(t, s.s)
+}
+
 func TestValidateSchema(t *testing.T) {
 	metaSchema = nil
 	data := `{"title": "test"}`


### PR DESCRIPTION
A typical use case is to merge data then validate against a schema.
However, if you want to validate multiple data sets against a single
schema, the API previously forced you to reparse the schema multiple
times, which is suboptimal. Now you can parse the schema once and
store it in an instance of Schema.